### PR TITLE
Bug fix in modify_file_line method

### DIFF
--- a/labs/core/admin.py
+++ b/labs/core/admin.py
@@ -1,4 +1,5 @@
 import json
+
 from django.contrib import admin
 from django.utils.safestring import mark_safe
 

--- a/labs/core/migrations/0002_workflowresult.py
+++ b/labs/core/migrations/0002_workflowresult.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("core", "0001_initial"),
     ]

--- a/labs/file_handler.py
+++ b/labs/file_handler.py
@@ -22,8 +22,8 @@ def modify_file_line(file_path: str, content: Union[str | List[str]], line_numbe
     # Count the number of lines in `content` and ensure it ends in `\n`
     if isinstance(content, list):
         content_lines_count = len(content)
-        if content_lines_count > 0 and not content[:-1].endswith("\n"):
-            content[:-1] += "\n"
+        if content_lines_count > 0 and not content[-1].endswith("\n"):
+            content[-1] += "\n"
 
     else:
         content_lines_count = len(content.splitlines())

--- a/labs/file_handler.py
+++ b/labs/file_handler.py
@@ -19,6 +19,17 @@ def create_file(file_path: str, content: str) -> None:
 def modify_file_line(file_path: str, content: Union[str | List[str]], line_number: int, overwrite=False) -> None:
     logger.info(f"{'Overwriting' if overwrite else 'Modifying'} file {file_path} line {line_number}")
 
+    # Count the number of lines in `content` and ensure it ends in `\n`
+    if isinstance(content, list):
+        content_lines_count = len(content)
+        if content_lines_count > 0 and not content[:-1].endswith("\n"):
+            content[:-1] += "\n"
+
+    else:
+        content_lines_count = len(content.splitlines())
+        if not content.endswith("\n"):
+            content += "\n"
+
     temp_file_path = f"{file_path}.tmp"
     skip_lines = 0
     try:
@@ -27,7 +38,7 @@ def modify_file_line(file_path: str, content: Union[str | List[str]], line_numbe
                 if current_line_number == line_number:
                     temp_file.writelines(content)
                     if overwrite:
-                        skip_lines = len(content)
+                        skip_lines = content_lines_count
 
                 if skip_lines > 0:
                     skip_lines -= 1

--- a/labs/llm/context.py
+++ b/labs/llm/context.py
@@ -30,7 +30,7 @@ You should:
     - Group related logic together to ensure clarity and cohesion.
     - Add meaningful comments to explain non-obvious logic or complex operations.
     - Ensure the code integrates seamlessly into the existing structure of the project.
-    - Perform the 'delete' operations in reverse line number order to avoid line shifting.
+    - Perform the 'delete' operations in  **reverse line number order** to avoid line shifting.
 """
 
 

--- a/labs/llm/prompt.py
+++ b/labs/llm/prompt.py
@@ -27,9 +27,9 @@ JSON_RESPONSE = json.dumps(
     {
         "steps": [
             {
-                "type": "Operation type: 'create', 'insert', 'overwrite', or 'delete'",
+                "type": "Operation type: 'create', 'update', 'overwrite', or 'delete'",
                 "path": "Absolute file path",
-                "content": "Content to write (required for 'create', 'insert', or 'overwrite')",
+                "content": "Content to write (required for 'create', 'update', or 'overwrite')",
                 "line": "Initial line number where the content should be written (or erased if 'delete')",
             }
         ]

--- a/labs/llm/prompt.py
+++ b/labs/llm/prompt.py
@@ -15,9 +15,9 @@ OUTPUT = """
 You must provide a JSON response in the following format: {json_response}
 
 Operation types explained:  
-    - 'create': Creates a new file with the specified content.
-    - 'update': Inserts the content at the specified line in an existing file. 
-    - 'overwrite': Replaces content at the specified line in the file.
+    - 'create': Creates a new file with the specified content.  
+    - 'update': Appends the content at the given line of an existing file.  
+    - 'overwrite': Replaces content at the specified line in the file.  
     - 'delete': Removes content from the specified line in the file.
 Ensure operations adhere to the JSON format provided.
 """
@@ -27,9 +27,9 @@ JSON_RESPONSE = json.dumps(
     {
         "steps": [
             {
-                "type": "Operation type: 'create', 'update', 'overwrite', or 'delete'",
+                "type": "Operation type: 'create', 'insert', 'overwrite', or 'delete'",
                 "path": "Absolute file path",
-                "content": "Content to write (required for 'create', 'update', or 'overwrite')",
+                "content": "Content to write (required for 'create', 'insert', or 'overwrite')",
                 "line": "Initial line number where the content should be written (or erased if 'delete')",
             }
         ]

--- a/labs/llm/prompt.py
+++ b/labs/llm/prompt.py
@@ -13,6 +13,13 @@ Based on the task description and the provided system context:
 
 OUTPUT = """
 You must provide a JSON response in the following format: {json_response}
+
+Operation types explained:  
+    - 'create': Creates a new file with the specified content.
+    - 'update': Appends the content at the specified line of an existing file. 
+    - 'overwrite': Replaces content at the specified line in the file.
+    - 'delete': Removes content from the specified line in the file.
+Ensure operations adhere to the JSON format provided.
 """
 
 
@@ -20,7 +27,7 @@ JSON_RESPONSE = json.dumps(
     {
         "steps": [
             {
-                "type": "'create', 'update', 'overwrite', or 'delete'",
+                "type": "Operation type: 'create', 'update', 'overwrite', or 'delete'",
                 "path": "Absolute file path",
                 "content": "Content to write (required for 'create', 'update', or 'overwrite')",
                 "line": "Initial line number where the content should be written (or erased if 'delete')",

--- a/labs/llm/prompt.py
+++ b/labs/llm/prompt.py
@@ -16,7 +16,7 @@ You must provide a JSON response in the following format: {json_response}
 
 Operation types explained:  
     - 'create': Creates a new file with the specified content.
-    - 'update': Appends the content at the specified line of an existing file. 
+    - 'update': Inserts the content at the specified line in an existing file. 
     - 'overwrite': Replaces content at the specified line in the file.
     - 'delete': Removes content from the specified line in the file.
 Ensure operations adhere to the JSON format provided.

--- a/labs/tasks/logging.py
+++ b/labs/tasks/logging.py
@@ -1,8 +1,7 @@
-from django.conf import settings
-from core.models import Model, WorkflowResult
-from config.redis_client import RedisStrictClient, RedisVariable
-
 from config.celery import app
+from config.redis_client import RedisStrictClient, RedisVariable
+from core.models import Model, WorkflowResult
+from django.conf import settings
 
 redis_client = RedisStrictClient(host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=0, decode_responses=True)
 


### PR DESCRIPTION
## What this PR change:

* Bug fix in `file_handler.modify_file_line` method
      * Overwrite operation overwrites a set of lines larger than what was in content
      * LLM assumes that when indicating the line number, each operation refers to that (or more lines) existing in `content`, so now it is verified and added `\n` at the end of the content to respect the assumption made by the LLM
* Added what each operation type does in prompt

## Reviewers:

- @kenvontucky 
- @JdFSilva 
- @cld-vasconcelos 


## Issues:

NA

## Print screens showing the changes:

NA