### PR TITLE
Fix python vectorizer, prompt and other little things

### DIFF
--- a/labs/config/redis_client.py
+++ b/labs/config/redis_client.py
@@ -2,7 +2,6 @@ from enum import Enum
 from typing import Union
 
 from django.conf import settings
-
 from redis import StrictRedis
 from redis.typing import EncodableT, ResponseT
 

--- a/labs/file_handler.py
+++ b/labs/file_handler.py
@@ -51,8 +51,9 @@ def modify_file_line(file_path: str, content: Union[str | List[str]], line_numbe
 
                 temp_file.write(line)
 
-            if line_number > current_line_number:
-                temp_file.writelines(content)
+            if not overwrite and line_number > current_line_number:
+                # If we reach this condition line_number + 1 does not apply, so we add a `\n` before
+                temp_file.writelines(f"\n{content}")
 
     except Exception as e:
         logger.error(f"Error modifying file {file_path}: {e}")

--- a/labs/file_handler.py
+++ b/labs/file_handler.py
@@ -32,6 +32,11 @@ def modify_file_line(file_path: str, content: Union[str | List[str]], line_numbe
 
     temp_file_path = f"{file_path}.tmp"
     skip_lines = 0
+
+    # Insert should be done in the next line
+    if not overwrite:
+        line_number += 1
+
     try:
         with open(file_path, "r") as original_file, open(temp_file_path, "w") as temp_file:
             for current_line_number, line in enumerate(original_file, start=1):
@@ -77,7 +82,7 @@ def get_file_content(file_path: str) -> str:
         content = ""
         with open(file_path, "r") as file:
             for line_number, line in enumerate(file, start=1):
-                content += "{:>{}}| {}".format(line_number, 4, line)
+                content += f"#{line_number}\n{line}"
 
         return content
 

--- a/labs/file_handler.py
+++ b/labs/file_handler.py
@@ -77,7 +77,7 @@ def get_file_content(file_path: str) -> str:
         content = ""
         with open(file_path, "r") as file:
             for line_number, line in enumerate(file, start=1):
-                content += f"{line_number}: {line}"
+                content += "{:>{}}| {}".format(line_number, 4, line)
 
         return content
 

--- a/labs/llm/context.py
+++ b/labs/llm/context.py
@@ -13,7 +13,7 @@ MIMETYPE_MD_NAME = {
     "text/x-python": "python",
 }
 
-CONTENT_TEMPLATE = "The following is the code in `{file}`:\n\n````{mimetype}\n{content}\n```"
+CONTENT_TEMPLATE = "The following is the code in `{file}`:\n\n```{mimetype}\n{content}\n```"
 PERSONA_CONTEXT = """
 You are an advanced software engineer assistant designed to resolve code-based tasks.
 You will receive:
@@ -30,7 +30,6 @@ You should:
     - Group related logic together to ensure clarity and cohesion.
     - Add meaningful comments to explain non-obvious logic or complex operations.
     - Ensure the code integrates seamlessly into the existing structure of the project.
-    - Perform **all** the operations in **reverse line number order** to avoid line shifting.
 """
 
 

--- a/labs/llm/context.py
+++ b/labs/llm/context.py
@@ -22,7 +22,7 @@ This is a Python repository for Revent, a photo contest API built with Django.
 You are an advanced software engineering assistant tasked with resolving code-related tasks. You will receive:
 - Task descriptions.
 - File names with line numbers and content as context.
-- Constraints (e.g., only modify migrations when explicitly required).
+- Constraints such as not modifying migrations unless explicitly required.
 
 Your environment is fully set up—no need to install packages.
 

--- a/labs/llm/context.py
+++ b/labs/llm/context.py
@@ -15,21 +15,44 @@ MIMETYPE_MD_NAME = {
 
 CONTENT_TEMPLATE = "The following is the code in `{file}`:\n\n```{mimetype}\n{content}\n```"
 PERSONA_CONTEXT = """
-You are an advanced software engineer assistant designed to resolve code-based tasks.
-You will receive:
-    1. A description of the task.
-    2. File names and their content (with line numbers) as context.
-    3. Constraints such as not modifying migrations unless explicitly required.
-    
-You should:
-    - Analyze the provided task description and associated context.
-    - Generate the necessary code changes to resolve the task.
-    - Ensure adherence to best practices for the programming language used.
-    - Avoid changes to migrations or unrelated files unless specified.
-    - Provide clean, organized, and ready-to-review code changes.
-    - Group related logic together to ensure clarity and cohesion.
-    - Add meaningful comments to explain non-obvious logic or complex operations.
-    - Ensure the code integrates seamlessly into the existing structure of the project.
+# Overview
+This is a Python repository for Revent, a photo contest API built with Django.
+
+# Guidance
+You are an advanced software engineering assistant tasked with resolving code-related tasks. You will receive:
+- Task descriptions.
+- File names with line numbers and content as context.
+- Constraints (e.g., only modify migrations when explicitly required).
+
+Your environment is fully set up—no need to install packages.
+
+# Task Guidelines
+- Solve problems with minimal, clean, and efficient code.
+- Avoid complexity: minimize branching logic, error handling, and unnecessary lines.
+
+# Code Style
+- Use Python's standard library/core packages when possible.
+- Prioritize readability, maintainability, and computational efficiency.
+- Avoid excessive loops, chains, and nested logic.
+- Use:
+  - Explicit imports (no `import *`).
+  - List comprehensions over loops (but keep them simple).
+  - f-strings for formatting.
+  - Type hints for all function signatures.
+  - Dataclasses for simple classes.
+  - Avoid:
+    - Excessive try/except blocks or nested error handling.
+    - Installing new packages or using make commands unless specified.
+
+# Testing
+- Place tests in the `tests` directory.
+- Use the `unittest` framework.
+- Write unit tests for all functions, covering edge cases and error conditions.
+- Aim for 100% test coverage with concise, comprehensive tests.
+
+# Resources
+- README.md: Contains code structure and workflow details (ignore human-specific dev instructions).
+- Makefile: Useful commands (refer to instructions in this file).
 """
 
 

--- a/labs/llm/context.py
+++ b/labs/llm/context.py
@@ -18,7 +18,7 @@ PERSONA_CONTEXT = """
 You are an advanced software engineer assistant designed to resolve code-based tasks.
 You will receive:
     1. A description of the task.
-    2. File names and their contents as context.
+    2. File names and their content (with line numbers) as context.
     3. Constraints such as not modifying migrations unless explicitly required.
     
 You should:
@@ -30,7 +30,7 @@ You should:
     - Group related logic together to ensure clarity and cohesion.
     - Add meaningful comments to explain non-obvious logic or complex operations.
     - Ensure the code integrates seamlessly into the existing structure of the project.
-    - Perform the 'delete' operations in  **reverse line number order** to avoid line shifting.
+    - Perform **all** the operations in **reverse line number order** to avoid line shifting.
 """
 
 

--- a/labs/llm/prompt.py
+++ b/labs/llm/prompt.py
@@ -16,7 +16,7 @@ You must provide a JSON response in the following format: {json_response}
 
 Operation types explained:  
     - 'create': Creates a new file with the specified content.  
-    - 'update': Appends the content at the given line of an existing file.  
+    - 'insert': Inserts the content at the given line of an existing file.  
     - 'overwrite': Replaces content at the specified line in the file.  
     - 'delete': Removes content from the specified line in the file.
 Ensure operations adhere to the JSON format provided.
@@ -27,9 +27,9 @@ JSON_RESPONSE = json.dumps(
     {
         "steps": [
             {
-                "type": "Operation type: 'create', 'update', 'overwrite', or 'delete'",
+                "type": "Operation type: 'create', 'insert', 'overwrite', or 'delete'",
                 "path": "Absolute file path",
-                "content": "Content to write (required for 'create', 'update', or 'overwrite')",
+                "content": "Content to write (required for 'create', 'insert', or 'overwrite')",
                 "line": "Initial line number where the content should be written (or erased if 'delete')",
             }
         ]

--- a/labs/parsers/python.py
+++ b/labs/parsers/python.py
@@ -209,14 +209,9 @@ def parse_python_file(file_path: str) -> str | dict:
         file_content = source.read()
 
     parser = PythonFileParser(file_name=file_path)
-    try:
-        tree = ast.parse(file_content, file_path)
-
-    except SyntaxError as e:
-        print(f"Syntax error at {file_path}: {e}")
-        return dict()
-
+    tree = ast.parse(file_content, file_path)
     parser.visit(tree)
+
     return parser.get_structure()
 
 

--- a/labs/tasks/llm.py
+++ b/labs/tasks/llm.py
@@ -3,7 +3,7 @@ import logging
 from typing import List, Optional
 
 from config.celery import app
-from config.redis_client import redis_client, RedisVariable
+from config.redis_client import RedisVariable, redis_client
 from core.models import Model, VectorizerModel
 from django.conf import settings
 from embeddings.embedder import Embedder
@@ -73,6 +73,7 @@ def find_embeddings_task(
         similarity_threshold,
         max_results,
     )
+    logger.debug(f"Retrieved files from embeddings match\n: {'\n'.join(files_path)}")
 
     if prefix:
         redis_client.set(RedisVariable.EMBEDDINGS, prefix=prefix, value=json.dumps(files_path))

--- a/labs/tasks/llm.py
+++ b/labs/tasks/llm.py
@@ -73,7 +73,6 @@ def find_embeddings_task(
         similarity_threshold,
         max_results,
     )
-    logger.debug(f"Retrieved files from embeddings match\n: {'\n'.join(files_path)}")
 
     if prefix:
         redis_client.set(RedisVariable.EMBEDDINGS, prefix=prefix, value=json.dumps(files_path))

--- a/labs/tasks/logging.py
+++ b/labs/tasks/logging.py
@@ -1,7 +1,6 @@
 from config.celery import app
-
+from config.redis_client import RedisVariable, redis_client
 from core.models import Model, WorkflowResult
-from config.redis_client import redis_client, RedisVariable
 
 
 @app.task

--- a/labs/tasks/repository.py
+++ b/labs/tasks/repository.py
@@ -3,7 +3,7 @@ import logging
 from typing import List, cast
 
 from config.celery import app
-from config.redis_client import redis_client, RedisVariable
+from config.redis_client import RedisVariable, redis_client
 from decorators import time_and_log_function
 from file_handler import create_file, delete_file_line, modify_file_line
 from github.github import GithubRequests

--- a/labs/tasks/repository.py
+++ b/labs/tasks/repository.py
@@ -25,12 +25,15 @@ def github_repository_data(prefix, token="", repository_owner="", repository_nam
 def apply_code_changes(llm_response):
     response = parse_llm_output(llm_response)
 
+    # We will sort the operations by file and by line number
+    sorted_steps = sorted(response.steps, key=lambda s: (s.path, s.line), reverse=True)
+
     files: List[str | None] = []
-    for step in response.steps:
+    for step in sorted_steps:
         match step.type:
             case "create":
                 create_file(step.path, step.content)
-            case "update":
+            case "insert":
                 modify_file_line(step.path, step.content, cast(int, step.line))
             case "overwrite":
                 modify_file_line(step.path, step.content, cast(int, step.line), overwrite=True)

--- a/labs/tasks/run.py
+++ b/labs/tasks/run.py
@@ -2,7 +2,7 @@ import os.path
 
 from celery import chain
 from config.celery import app
-from config.redis_client import redis_client, RedisVariable
+from config.redis_client import RedisVariable, redis_client
 from tasks import (
     apply_code_changes_task,
     clone_repository_task,

--- a/labs/tests/test_file_handler.py
+++ b/labs/tests/test_file_handler.py
@@ -26,19 +26,26 @@ class TestFileHandler(TestCase):
     Line 3
     Line 4
     """
-    INSERT_EOF_LINE = 4
+    INSERT_EOF_LINE = 6
     INSERT_EOF_EXPECTED_CONTENT = """
     Line 1
     Line 2
     Line 4
+    
     Line 3
-    """
+"""
     # Overwrite variables
     OVERWRITE_LINE = 4
     OVERWRITE_LINE_EXPECTED_CONTENT = """
     Line 1
     Line 2
     Line 3
+    """
+    OVERWRITE_EOF_LINE = 6
+    OVERWRITE_EOF_EXPECTED_CONTENT = """
+    Line 1
+    Line 2
+    Line 4
     """
     # Delete variables
     DELETE_LINE = 4
@@ -49,7 +56,7 @@ class TestFileHandler(TestCase):
 
     def assertFileContentEqual(self, file_path, expected_content):
         with open(file_path, "r") as file_handler:
-            self.assertEqual(file_handler.read(), expected_content)
+            self.assertEqual(expected_content, file_handler.read())
 
     def setUp(self):
         self.temporary_file = NamedTemporaryFile(mode="w+", delete=False)
@@ -76,17 +83,21 @@ class TestFileHandler(TestCase):
         modify_file_line(self.temporary_file.name, self.NEW_CONTENT, self.INSERT_LINE)
         self.assertFileContentEqual(self.temporary_file.name, self.INSERT_LINE_EXPECTED_CONTENT)
 
+    def test_insert_end_of_file(self):
+        modify_file_line(self.temporary_file.name, self.NEW_CONTENT, self.INSERT_EOF_LINE)
+        self.assertFileContentEqual(self.temporary_file.name, self.INSERT_EOF_EXPECTED_CONTENT)
+
     def test_overwrite_file_line(self):
         modify_file_line(self.temporary_file.name, self.NEW_CONTENT, self.OVERWRITE_LINE, overwrite=True)
         self.assertFileContentEqual(self.temporary_file.name, self.OVERWRITE_LINE_EXPECTED_CONTENT)
 
+    def test_overwrite_end_of_file(self):
+        modify_file_line(self.temporary_file.name, self.NEW_CONTENT, self.OVERWRITE_EOF_LINE, overwrite=True)
+        self.assertFileContentEqual(self.temporary_file.name, self.OVERWRITE_EOF_EXPECTED_CONTENT)
+
     def test_delete_file_line(self):
         delete_file_line(self.temporary_file.name, self.DELETE_LINE)
         self.assertFileContentEqual(self.temporary_file.name, self.DELETE_LINE_EXPECTED_CONTENT)
-
-    def test_insert_at_end_of_file(self):
-        modify_file_line(self.temporary_file.name, self.NEW_CONTENT, self.INSERT_EOF_LINE)
-        self.assertFileContentEqual(self.temporary_file.name, self.INSERT_EOF_EXPECTED_CONTENT)
 
     def tearDown(self):
         os.remove(self.temporary_file.name)

--- a/labs/tests/test_file_handler.py
+++ b/labs/tests/test_file_handler.py
@@ -11,14 +11,14 @@ class TestFileHandler(TestCase):
     Line 2
     Line 4
     """
-    READ_FILE_EXPECTED_CONTENT = """
-    #1
-    Line 1
-    #2
-    Line 2
-    #3
-    Line 4
-    """
+    NEW_CONTENT = "    Line 3\n"
+    # Read variables
+    READ_FILE_EXPECTED_CONTENT = """     1 | 
+     2 |     Line 1
+     3 |     Line 2
+     4 |     Line 4
+     5 |     """
+    # Insert variables
     INSERT_LINE = 3
     INSERT_LINE_EXPECTED_CONTENT = """
     Line 1
@@ -26,18 +26,26 @@ class TestFileHandler(TestCase):
     Line 3
     Line 4
     """
+    INSERT_EOF_LINE = 4
+    INSERT_EOF_EXPECTED_CONTENT = """
+    Line 1
+    Line 2
+    Line 4
+    Line 3
+    """
+    # Overwrite variables
     OVERWRITE_LINE = 4
     OVERWRITE_LINE_EXPECTED_CONTENT = """
     Line 1
     Line 2
     Line 3
     """
+    # Delete variables
     DELETE_LINE = 4
     DELETE_LINE_EXPECTED_CONTENT = """
     Line 1
     Line 2
     """
-    NEW_CONTENT = "    Line 3\n"
 
     def assertFileContentEqual(self, file_path, expected_content):
         with open(file_path, "r") as file_handler:
@@ -49,7 +57,7 @@ class TestFileHandler(TestCase):
         self.temporary_file.flush()
         self.temporary_file.close()
 
-    def text_get_file_content(self):
+    def test_get_file_content(self):
         content = get_file_content(self.temporary_file.name)
         self.assertEqual(content, self.READ_FILE_EXPECTED_CONTENT)
 
@@ -75,6 +83,10 @@ class TestFileHandler(TestCase):
     def test_delete_file_line(self):
         delete_file_line(self.temporary_file.name, self.DELETE_LINE)
         self.assertFileContentEqual(self.temporary_file.name, self.DELETE_LINE_EXPECTED_CONTENT)
+
+    def test_insert_at_end_of_file(self):
+        modify_file_line(self.temporary_file.name, self.NEW_CONTENT, self.INSERT_EOF_LINE)
+        self.assertFileContentEqual(self.temporary_file.name, self.INSERT_EOF_EXPECTED_CONTENT)
 
     def tearDown(self):
         os.remove(self.temporary_file.name)


### PR DESCRIPTION
## What this PR change:

* Add file path to embeddings to allow retrieve files by its name in prompt (like "Add feature X to this_file.py")
* Using python vectorizer, files with syntax errors not are loaded into embeddings in chunks.
* Removed useless information added to embeddings when using python vectorizer (due to the way embeddings are used now)
* Add line numbers to files sent in context following almost the same format of the console command `nl -ba file.txt`
* Changed prompt to a more complete one adding a little project overview, general guidance, task guidelines, expected code style, testing and resources description showing better LLM results.
* Sort files and steps: Now doesn't matter how LLM results response are, they are always sorted by file name and reverse line order to avoid operations that can cause line shifting
* Added file_handler.py functions tests to ensure that file handle functions act as expected

## Reviewers:

- @kenvontucky 
- @JdFSilva 
- @cld-vasconcelos 


## Issues:

* #178 (most of the changed don't meet what is described in the issue)

## Print screens showing the changes:

![Captura de ecrã 2025-01-16, às 12 01 09](https://github.com/user-attachments/assets/d805053f-3ef2-4055-8e00-ef56c262da39)

# Findings:

Using **Chunck Vectorizer** and `GPT embeddings` model (described in the image) this is the result of retrieved embeddings for prompt `Add created_at and updated_at fields to User model`:
![Captura de ecrã 2025-01-16, às 12 03 12](https://github.com/user-attachments/assets/0accf30c-7de8-44e8-8424-91534f5a4eb8)

There are the results for the same prompt using `nomic`embeddings model (described in the image):
![Captura de ecrã 2025-01-16, às 12 04 37](https://github.com/user-attachments/assets/0f86f6c3-3e19-47f2-8829-cae1be5c1bef)

As we can see, the `models.py` file isn't retrieved and the other files are just garbage for what was asked