### PR TITLE
update deprecated --no-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR $PYSETUP_PATH
 
 # Install production dependencies
 COPY poetry.lock pyproject.toml ./
-RUN poetry install --no-root --no-dev
+RUN poetry install --no-root --without dev
 
 
 # `production` image


### PR DESCRIPTION
Replaced deprecated` --no-dev` with `--without dev` to exclude development dependencies, which effectively aligns with our two-group setup. Could also use `--only main`. 

https://python-poetry.org/docs/cli/#install