### PR TITLE
corrected behavior of select models in admin

### DIFF
--- a/labs/core/admin.py
+++ b/labs/core/admin.py
@@ -1,20 +1,13 @@
 from django.contrib import admin
 from django.urls import reverse
 
-from .forms import ProjectForm
+from .forms import ProjectForm, ModelFormSet
 from .mixins import JSONFormatterMixin
 from .models import Model, Project, Prompt, Variable, VectorizerModel, WorkflowResult
 
-
 @admin.register(Model)
 class ModelAdmin(admin.ModelAdmin):
-    list_display = (
-        "id",
-        "model_type",
-        "provider",
-        "model_name",
-        "active",
-    )
+    list_display = ("id", "model_type", "provider", "model_name", "active")
     list_display_links = ("id",)
     list_editable = ("model_type", "provider", "model_name", "active")
     list_filter = ("provider", "model_name")
@@ -25,6 +18,10 @@ class ModelAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    def get_changelist_formset(self, request, **kwargs):
+        kwargs["formset"] = ModelFormSet
+        return super().get_changelist_formset(request, **kwargs)
 
 
 @admin.register(Variable)

--- a/labs/core/forms.py
+++ b/labs/core/forms.py
@@ -43,9 +43,6 @@ class ModelFormSet(BaseModelFormSet):
         errors = []
 
         for form in self.forms:
-            if not form.cleaned_data or form.cleaned_data.get("DELETE", False):
-                continue
-
             model_type = form.cleaned_data["model_type"]
             if model_type in counts and form.cleaned_data["active"]:
                 counts[model_type] += 1

--- a/labs/core/forms.py
+++ b/labs/core/forms.py
@@ -1,11 +1,13 @@
 import os
 
-from core.models import Project
-from django import forms
+from core.models import Project, ModelTypeEnum
+from django.forms import (
+    ModelForm, BaseModelFormSet, ValidationError, ChoiceField
+)
 from django.conf import settings
 
 
-class ProjectForm(forms.ModelForm):
+class ProjectForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.get_projects_directories()
@@ -17,7 +19,7 @@ class ProjectForm(forms.ModelForm):
             if os.path.isdir(full_directory_path):
                 directories.append((full_directory_path, directory))
 
-        self.fields["path"] = forms.ChoiceField(
+        self.fields["path"] = ChoiceField(
             choices=directories,
             label="Project directory",
             required=True,
@@ -26,3 +28,43 @@ class ProjectForm(forms.ModelForm):
     class Meta:
         model = Project
         fields = ["name", "description", "path", "url"]
+
+
+class ModelFormSet(BaseModelFormSet):
+    def clean(self):
+        super().clean()
+
+        embedding_count = 0
+        llm_count = 0
+        errors = []
+
+        embedding_name = ModelTypeEnum.EMBEDDING.name
+        llm_name = ModelTypeEnum.LLM.name
+
+        for form in self.forms:
+            if not form.cleaned_data or form.cleaned_data.get("DELETE", False):
+                continue
+
+            model_type = form.cleaned_data["model_type"]
+            active = form.cleaned_data["active"]
+
+            if model_type == embedding_name and active:
+                embedding_count += 1
+            elif model_type == llm_name and active:
+                llm_count += 1
+
+        if embedding_count != 1:
+            errors.append(
+                ValidationError(
+                    f"You must have exactly 1 active {embedding_name}, found {embedding_count}."
+                )
+            )
+        if llm_count != 1:
+            errors.append(
+                ValidationError(
+                    f"You must have exactly 1 active {llm_name}, found {llm_count}."
+                )
+            )
+
+        if errors:
+            raise ValidationError(errors)

--- a/labs/core/models.py
+++ b/labs/core/models.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Literal, Tuple
 
 from django.core.exceptions import ValidationError
-from django.db import models, transaction
+from django.db import models
 from django.db.models import Q
 from embeddings.embedder import Embedder
 from embeddings.ollama import OllamaEmbedder

--- a/labs/core/models.py
+++ b/labs/core/models.py
@@ -3,7 +3,8 @@ from enum import Enum
 from typing import Literal, Tuple
 
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
+from django.db.models import Q
 from embeddings.embedder import Embedder
 from embeddings.ollama import OllamaEmbedder
 from embeddings.openai import OpenAIEmbedder
@@ -113,14 +114,22 @@ class Model(models.Model):
         Variable.load_provider_keys(model.provider)
         return provider_model_class[model.provider][model_type], model.model_name
 
-    def save(self, *args, **kwargs):
-        Model.objects.filter(model_type=self.model_type, active=True).exclude(id=self.id).update(active=False)
-        super().save(*args, **kwargs)
-
     def __str__(self):
         return f"{self.model_type} {self.provider} {self.model_name}"
 
     class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["model_type"],
+                condition=Q(model_type=ModelTypeEnum.EMBEDDING, active=True),
+                name="unique_active_embedding"
+            ),
+            models.UniqueConstraint(
+                fields=["model_type"],
+                condition=Q(model_type=ModelTypeEnum.LLM, active=True),
+                name="unique_active_llm"
+            ),
+        ]
         indexes = [models.Index(fields=["provider", "model_name"])]
 
 


### PR DESCRIPTION
- Removed the old save() logic from Model that was not working correctly.
- Kept the DB constraints to ensure there is never more than one active EMBEDDING or LLM.
- Created a custom ModelFormSet that checks clean() for exactly one active EMBEDDING and one active LLM.
- Overrode get_changelist_formset() in the ModelAdmin to use this custom formset, showing a clear error if the user doesn’t pick exactly one of each (https://github.com/django/django/blob/stable/5.1.x/django/contrib/admin/options.py#L915)